### PR TITLE
Use DataSource for MySqlStorageService and improve logging

### DIFF
--- a/src/main/java/com/kookykraftmc/market/Market.java
+++ b/src/main/java/com/kookykraftmc/market/Market.java
@@ -136,7 +136,7 @@ public class Market {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Failed to initialize Market", e);
         }
     }
 
@@ -369,7 +369,7 @@ public class Market {
         try {
             HoconConfigurationLoader.builder().setSink(() -> new BufferedWriter(stringWriter)).build().save(node);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Failed to serialize item", e);
         }
         return stringWriter.toString();
     }
@@ -379,7 +379,7 @@ public class Market {
         try {
             node = HoconConfigurationLoader.builder().setSource(() -> new BufferedReader(new StringReader(item))).build().load();
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Failed to deserialize item stack", e);
         }
         DataView dataView = DataTranslators.CONFIGURATION_NODE.translate(node);
         return getGame().getDataManager().deserialize(ItemStack.class, dataView);

--- a/src/main/java/com/kookykraftmc/market/MySqlStorageService.java
+++ b/src/main/java/com/kookykraftmc/market/MySqlStorageService.java
@@ -1,5 +1,8 @@
 package com.kookykraftmc.market;
 
+import org.slf4j.Logger;
+
+import javax.sql.DataSource;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,16 +15,19 @@ import java.util.List;
  */
 public class MySqlStorageService {
 
-    private final Connection connection;
+    private final DataSource dataSource;
+    private final Logger logger;
     private static final String EVENTS_TABLE = "market_events";
 
-    public MySqlStorageService(Connection connection) throws SQLException {
-        this.connection = connection;
+    public MySqlStorageService(DataSource dataSource, Logger logger) throws SQLException {
+        this.dataSource = dataSource;
+        this.logger = logger;
         init();
     }
 
     private void init() throws SQLException {
-        try (Statement st = connection.createStatement()) {
+        try (Connection connection = dataSource.getConnection();
+             Statement st = connection.createStatement()) {
             st.executeUpdate("CREATE TABLE IF NOT EXISTS " + EVENTS_TABLE + " (" +
                     "id INT AUTO_INCREMENT PRIMARY KEY," +
                     "type VARCHAR(64) NOT NULL," +
@@ -34,36 +40,39 @@ public class MySqlStorageService {
 
     public void insertBlacklistEvent(String type, String item) {
         String sql = "INSERT INTO " + EVENTS_TABLE + "(type, item) VALUES (?, ?)";
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setString(1, type);
             ps.setString(2, item);
             ps.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.error("Failed to insert blacklist event", e);
         }
     }
 
     public List<MarketEvent> pollEvents() {
         List<MarketEvent> events = new ArrayList<>();
         String sql = "SELECT id, type, item FROM " + EVENTS_TABLE + " WHERE processed = 0";
-        try (PreparedStatement ps = connection.prepareStatement(sql);
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql);
              ResultSet rs = ps.executeQuery()) {
             while (rs.next()) {
                 events.add(new MarketEvent(rs.getInt("id"), rs.getString("type"), rs.getString("item")));
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.error("Failed to poll events", e);
         }
         return events;
     }
 
     public void markProcessed(int id) {
         String sql = "UPDATE " + EVENTS_TABLE + " SET processed = 1 WHERE id = ?";
-        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setInt(1, id);
             ps.executeUpdate();
         } catch (SQLException e) {
-            e.printStackTrace();
+            logger.error("Failed to mark event as processed", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Switch MySqlStorageService to use a Hikari DataSource instead of a persistent Connection
- Acquire and close connections within methods via try-with-resources
- Replace printStackTrace calls with logger.error for consistent logging

## Testing
- `JAVA_HOME=~/.local/share/mise/installs/java/11 ./gradlew test` *(fails: Plugin [id: 'org.spongepowered.plugin', version: '0.8.1', artifact: 'org.spongepowered:spongegradle:0.8.1'] was not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a693ac143083269b6c3b83fb1dbb5d