### PR TITLE
Use scheduler for MySQL listener

### DIFF
--- a/src/main/java/com/kookykraftmc/market/MySqlListener.java
+++ b/src/main/java/com/kookykraftmc/market/MySqlListener.java
@@ -3,14 +3,13 @@ package com.kookykraftmc.market;
 import java.util.List;
 
 /**
- * Background task that polls the {@code market_events} table and applies
+ * Task that polls the {@code market_events} table and applies
  * changes to the local server.
  */
 public class MySqlListener implements Runnable {
 
     private final Market market;
     private final MySqlStorageService storageService;
-    private volatile boolean running = true;
 
     public MySqlListener(Market market, MySqlStorageService storageService) {
         this.market = market;
@@ -19,23 +18,15 @@ public class MySqlListener implements Runnable {
 
     @Override
     public void run() {
-        while (running) {
-            List<MarketEvent> events = storageService.pollEvents();
-            for (MarketEvent event : events) {
-                String type = event.getType();
-                if ("BLACKLIST_ADD".equalsIgnoreCase(type)) {
-                    market.addIDToBlackList(event.getItem());
-                } else if ("BLACKLIST_REMOVE".equalsIgnoreCase(type)) {
-                    market.rmIDFromBlackList(event.getItem());
-                }
-                storageService.markProcessed(event.getId());
+        List<MarketEvent> events = storageService.pollEvents();
+        for (MarketEvent event : events) {
+            String type = event.getType();
+            if ("BLACKLIST_ADD".equalsIgnoreCase(type)) {
+                market.addIDToBlackList(event.getItem());
+            } else if ("BLACKLIST_REMOVE".equalsIgnoreCase(type)) {
+                market.rmIDFromBlackList(event.getItem());
             }
-            try {
-                Thread.sleep(1000L);
-            } catch (InterruptedException e) {
-                running = false;
-                Thread.currentThread().interrupt();
-            }
+            storageService.markProcessed(event.getId());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Poll MySQL events with Sponge scheduled task instead of custom thread
- Cancel scheduled MySQL task on server shutdown
- Simplify MySqlListener into single-run task

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a3187064832690a19c88385054c7