### PR TITLE
feat: allow selecting MySQL or Redis storage

### DIFF
--- a/src/main/java/com/kookykraftmc/market/Market.java
+++ b/src/main/java/com/kookykraftmc/market/Market.java
@@ -49,7 +49,11 @@ import redis.clients.jedis.Transaction;
 
 import java.io.*;
 import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -89,6 +93,9 @@ public class Market {
 
     private Database database;
 
+    // Flag indicating which backend is used for data storage
+    private boolean useMySql;
+
     private Cause marketCause;
     private List<String> blacklistedItems = Lists.newArrayList();
 
@@ -110,8 +117,8 @@ public class Market {
 
                 this.cfg.getNode("Market", "Sponge", "Server").setValue("TEST");
 
-                // MySQL defaults
-                this.cfg.getNode("MySQL", "Enabled").setValue(false);
+                // Storage selection and MySQL defaults
+                this.cfg.getNode("Storage", "Type").setValue("redis");
                 this.cfg.getNode("MySQL", "Host").setValue("localhost");
                 this.cfg.getNode("MySQL", "Port").setValue(3306);
                 this.cfg.getNode("MySQL", "Database").setValue("market");
@@ -123,13 +130,12 @@ public class Market {
 
             this.cfg = this.configManager.load();
 
-            this.redisPort = cfg.getNode("Redis", "Port").getInt();
-            this.redisHost = cfg.getNode("Redis", "Host").getString();
-            this.redisPass = cfg.getNode("Redis", "Password").getString();
             this.serverName = cfg.getNode("Market", "Sponge", "Server").getString();
 
-            boolean mysqlEnabled = cfg.getNode("MySQL", "Enabled").getBoolean(false);
-            if (mysqlEnabled) {
+            String storageType = cfg.getNode("Storage", "Type").getString("redis");
+            useMySql = "mysql".equalsIgnoreCase(storageType);
+
+            if (useMySql) {
                 String sqlHost = cfg.getNode("MySQL", "Host").getString("localhost");
                 int sqlPort = cfg.getNode("MySQL", "Port").getInt(3306);
                 String sqlDatabase = cfg.getNode("MySQL", "Database").getString("market");
@@ -137,19 +143,15 @@ public class Market {
                 String sqlPassword = cfg.getNode("MySQL", "Password").getString("");
                 database = new Database(sqlHost, sqlPort, sqlDatabase, sqlUser, sqlPassword, logger);
                 database.runMigrations();
-
-                try {
-                    sqlStorage = new MySqlStorageService(database.getDataSource(), logger);
-                    subscribe();
-                } catch (SQLException e) {
-                    logger.error("Failed to initialize MySQL storage service", e);
-                }
-            }
-
-            if (this.cfg.getNode("Redis", "Use-password").getBoolean()) {
-                jedisPool = setupRedis(this.redisHost, this.redisPort, this.redisPass);
             } else {
-                jedisPool = setupRedis(this.redisHost, this.redisPort);
+                this.redisPort = cfg.getNode("Redis", "Port").getInt();
+                this.redisHost = cfg.getNode("Redis", "Host").getString();
+                this.redisPass = cfg.getNode("Redis", "Password").getString();
+                if (this.cfg.getNode("Redis", "Use-password").getBoolean()) {
+                    jedisPool = setupRedis(this.redisHost, this.redisPort, this.redisPass);
+                } else {
+                    jedisPool = setupRedis(this.redisHost, this.redisPort);
+                }
             }
 
         } catch (Exception e) {
@@ -163,8 +165,21 @@ public class Market {
         // SpongeAPI 7: use EventContext + plugin instance/container in the Cause
         marketCause = Cause.of(EventContext.empty(), this);
 
-        try (Jedis jedis = getJedis().getResource()) {
-            blacklistedItems = Lists.newArrayList(jedis.hgetAll(RedisKeys.BLACKLIST).keySet());
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT item FROM blacklist");
+                 ResultSet rs = ps.executeQuery()) {
+                blacklistedItems = new ArrayList<>();
+                while (rs.next()) {
+                    blacklistedItems.add(rs.getString("item"));
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to load blacklist from MySQL", e);
+            }
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                blacklistedItems = Lists.newArrayList(jedis.hgetAll(RedisKeys.BLACKLIST).keySet());
+            }
         }
 
         CommandSpec createMarketCmd = CommandSpec.builder()
@@ -288,8 +303,41 @@ public class Market {
     }
 
     private void updateUUIDCache(String uuid, String name) {
-        try (Jedis jedis = getJedis().getResource()) {
-            jedis.hset(RedisKeys.UUID_CACHE, uuid, name);
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("REPLACE INTO uuid_cache (uuid, name) VALUES (?, ?)")) {
+                ps.setString(1, uuid);
+                ps.setString(2, name);
+                ps.executeUpdate();
+            } catch (SQLException e) {
+                logger.error("Failed to update UUID cache", e);
+            }
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                jedis.hset(RedisKeys.UUID_CACHE, uuid, name);
+            }
+        }
+    }
+
+    private String getNameFromUUID(String uuid) {
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT name FROM uuid_cache WHERE uuid = ?")) {
+                ps.setString(1, uuid);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        return rs.getString("name");
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to lookup UUID", e);
+            }
+            return uuid;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                String name = jedis.hget(RedisKeys.UUID_CACHE, uuid);
+                return name != null ? name : uuid;
+            }
         }
     }
 
@@ -412,192 +460,366 @@ public class Market {
     }
 
     public int addListing(Player player, ItemStack itemStack, int quantityPerSale, int price) {
-        try (Jedis jedis = getJedis().getResource()) {
-            // if there are fewer items than they want to sell every time, return 0
-            if (itemStack.getQuantity() < quantityPerSale || quantityPerSale <= 0 || isBlacklisted(itemStack)) return 0;
-            if (!jedis.exists(RedisKeys.lastMarketId())) {
-                jedis.set(RedisKeys.lastMarketId(), String.valueOf(1));
-                int id = 1;
-                String key = RedisKeys.marketItemKey(String.valueOf(id));
-                Transaction m = jedis.multi();
-                m.hset(key, "Item", serializeItem(itemStack));
-                m.hset(key, "Seller", player.getUniqueId().toString());
-                m.hset(key, "Stock", String.valueOf(itemStack.getQuantity()));
-                m.hset(key, "Price", String.valueOf(price));
-                m.hset(key, "Quantity", String.valueOf(quantityPerSale));
-                m.exec();
+        if (useMySql) {
+            if (itemStack.getQuantity() < quantityPerSale || quantityPerSale <= 0 || isBlacklisted(itemStack)) {
+                return 0;
+            }
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement(
+                         "INSERT INTO listings (seller_uuid, item, stock, price, quantity) VALUES (?, ?, ?, ?, ?)",
+                         Statement.RETURN_GENERATED_KEYS)) {
+                ps.setString(1, player.getUniqueId().toString());
+                ps.setString(2, serializeItem(itemStack));
+                ps.setInt(3, itemStack.getQuantity());
+                ps.setInt(4, price);
+                ps.setInt(5, quantityPerSale);
+                ps.executeUpdate();
+                try (ResultSet rs = ps.getGeneratedKeys()) {
+                    if (rs.next()) {
+                        return rs.getInt(1);
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to add listing", e);
+            }
+            return 0;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                // if there are fewer items than they want to sell every time, return 0
+                if (itemStack.getQuantity() < quantityPerSale || quantityPerSale <= 0 || isBlacklisted(itemStack)) return 0;
+                if (!jedis.exists(RedisKeys.lastMarketId())) {
+                    jedis.set(RedisKeys.lastMarketId(), String.valueOf(1));
+                    int id = 1;
+                    String key = RedisKeys.marketItemKey(String.valueOf(id));
+                    Transaction m = jedis.multi();
+                    m.hset(key, "Item", serializeItem(itemStack));
+                    m.hset(key, "Seller", player.getUniqueId().toString());
+                    m.hset(key, "Stock", String.valueOf(itemStack.getQuantity()));
+                    m.hset(key, "Price", String.valueOf(price));
+                    m.hset(key, "Quantity", String.valueOf(quantityPerSale));
+                    m.exec();
 
-                jedis.hset(RedisKeys.forSale(), String.valueOf(id), player.getUniqueId().toString());
+                    jedis.hset(RedisKeys.forSale(), String.valueOf(id), player.getUniqueId().toString());
 
-                jedis.incr(RedisKeys.lastMarketId());
+                    jedis.incr(RedisKeys.lastMarketId());
 
-                return id;
-            } else {
-                int id = Integer.parseInt(jedis.get(RedisKeys.lastMarketId()));
-                String key = RedisKeys.marketItemKey(String.valueOf(id));
-                if (checkForOtherListings(itemStack, player.getUniqueId().toString())) return -1;
+                    return id;
+                } else {
+                    int id = Integer.parseInt(jedis.get(RedisKeys.lastMarketId()));
+                    String key = RedisKeys.marketItemKey(String.valueOf(id));
+                    if (checkForOtherListings(itemStack, player.getUniqueId().toString())) return -1;
 
-                Transaction m = jedis.multi();
-                m.hset(key, "Item", serializeItem(itemStack));
-                m.hset(key, "Seller", player.getUniqueId().toString());
-                m.hset(key, "Stock", String.valueOf(itemStack.getQuantity()));
-                m.hset(key, "Price", String.valueOf(price));
-                m.hset(key, "Quantity", String.valueOf(quantityPerSale));
-                m.exec();
+                    Transaction m = jedis.multi();
+                    m.hset(key, "Item", serializeItem(itemStack));
+                    m.hset(key, "Seller", player.getUniqueId().toString());
+                    m.hset(key, "Stock", String.valueOf(itemStack.getQuantity()));
+                    m.hset(key, "Price", String.valueOf(price));
+                    m.hset(key, "Quantity", String.valueOf(quantityPerSale));
+                    m.exec();
 
-                jedis.hset(RedisKeys.forSale(), String.valueOf(id), player.getUniqueId().toString());
+                    jedis.hset(RedisKeys.forSale(), String.valueOf(id), player.getUniqueId().toString());
 
-                jedis.incr(RedisKeys.lastMarketId());
+                    jedis.incr(RedisKeys.lastMarketId());
 
-                return id;
+                    return id;
+                }
             }
         }
     }
 
     private boolean checkForOtherListings(ItemStack itemStack, String s) {
-        try (Jedis jedis = getJedis().getResource()) {
-            Map<String, String> d = jedis.hgetAll(RedisKeys.forSale());
-
-            Map<String, String> e = d.entrySet().stream()
-                    .filter(stringStringEntry -> stringStringEntry.getValue().equals(s))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            if (e.size() == 0) return false;
-            else {
-                final boolean[] hasOther = {false};
-                e.forEach((s1, s2) -> {
-                    Optional<ItemStack> ooi = deserializeItemStack(jedis.hget(RedisKeys.marketItemKey(s1), "Item"));
-                    if (!ooi.isPresent()) return;
-                    if (matchItemStacks(ooi.get(), itemStack)) {
-                        hasOther[0] = true;
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT item FROM listings WHERE seller_uuid = ?")) {
+                ps.setString(1, s);
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        Optional<ItemStack> existing = deserializeItemStack(rs.getString("item"));
+                        if (existing.isPresent() && matchItemStacks(existing.get(), itemStack)) {
+                            return true;
+                        }
                     }
-                });
-                return hasOther[0];
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to check listings", e);
+            }
+            return false;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                Map<String, String> d = jedis.hgetAll(RedisKeys.forSale());
+
+                Map<String, String> e = d.entrySet().stream()
+                        .filter(stringStringEntry -> stringStringEntry.getValue().equals(s))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                if (e.size() == 0) return false;
+                else {
+                    final boolean[] hasOther = {false};
+                    e.forEach((s1, s2) -> {
+                        Optional<ItemStack> ooi = deserializeItemStack(jedis.hget(RedisKeys.marketItemKey(s1), "Item"));
+                        if (!ooi.isPresent()) return;
+                        if (matchItemStacks(ooi.get(), itemStack)) {
+                            hasOther[0] = true;
+                        }
+                    });
+                    return hasOther[0];
+                }
             }
         }
     }
 
     public PaginationList getListings() {
-        try (Jedis jedis = getJedis().getResource()) {
-            Set<String> openListings = jedis.hgetAll(RedisKeys.forSale()).keySet();
+        if (useMySql) {
             List<Text> texts = new ArrayList<>();
-            for (String openListing : openListings) {
-                Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(openListing));
-                Text.Builder l = Text.builder();
-                Optional<ItemStack> is = deserializeItemStack(listing.get("Item"));
-                if (!is.isPresent()) continue;
-                l.append(Texts.quickItemFormat(is.get()));
-                l.append(Text.of(" "));
-                l.append(Text.of(TextColors.WHITE, "@"));
-                l.append(Text.of(" "));
-                l.append(Text.of(TextColors.GREEN, "$" + listing.get("Price")));
-                l.append(Text.of(" "));
-                l.append(Text.of(TextColors.WHITE, "for"));
-                l.append(Text.of(" "));
-                l.append(Text.of(TextColors.GREEN, listing.get("Quantity") + "x"));
-                l.append(Text.of(" "));
-                l.append(Text.of(TextColors.WHITE, "Seller:"));
-                l.append(Text.of(TextColors.LIGHT_PURPLE, " " + jedis.hget(RedisKeys.UUID_CACHE, listing.get("Seller"))));
-                l.append(Text.of(" "));
-                l.append(Text.builder()
-                        .color(TextColors.GREEN)
-                        .onClick(TextActions.runCommand("/market check " + openListing))
-                        .append(Text.of("[Info]"))
-                        .onHover(TextActions.showText(Text.of("View more info about this listing.")))
-                        .build());
-
-                texts.add(l.build());
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT id, seller_uuid, item, price, quantity FROM listings");
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Text.Builder l = Text.builder();
+                    Optional<ItemStack> is = deserializeItemStack(rs.getString("item"));
+                    if (!is.isPresent()) continue;
+                    l.append(Texts.quickItemFormat(is.get()));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.WHITE, "@"));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.GREEN, "$" + rs.getInt("price")));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.WHITE, "for"));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.GREEN, rs.getInt("quantity") + "x"));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.WHITE, "Seller:"));
+                    l.append(Text.of(TextColors.LIGHT_PURPLE, " " + getNameFromUUID(rs.getString("seller_uuid"))));
+                    l.append(Text.of(" "));
+                    l.append(Text.builder()
+                            .color(TextColors.GREEN)
+                            .onClick(TextActions.runCommand("/market check " + rs.getInt("id")))
+                            .append(Text.of("[Info]"))
+                            .onHover(TextActions.showText(Text.of("View more info about this listing.")))
+                            .build());
+                    texts.add(l.build());
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to get listings", e);
             }
             return getPaginationService().builder().contents(texts).title(Texts.MARKET_LISTINGS).build();
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                Set<String> openListings = jedis.hgetAll(RedisKeys.forSale()).keySet();
+                List<Text> texts = new ArrayList<>();
+                for (String openListing : openListings) {
+                    Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(openListing));
+                    Text.Builder l = Text.builder();
+                    Optional<ItemStack> is = deserializeItemStack(listing.get("Item"));
+                    if (!is.isPresent()) continue;
+                    l.append(Texts.quickItemFormat(is.get()));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.WHITE, "@"));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.GREEN, "$" + listing.get("Price")));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.WHITE, "for"));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.GREEN, listing.get("Quantity") + "x"));
+                    l.append(Text.of(" "));
+                    l.append(Text.of(TextColors.WHITE, "Seller:"));
+                    l.append(Text.of(TextColors.LIGHT_PURPLE, " " + jedis.hget(RedisKeys.UUID_CACHE, listing.get("Seller"))));
+                    l.append(Text.of(" "));
+                    l.append(Text.builder()
+                            .color(TextColors.GREEN)
+                            .onClick(TextActions.runCommand("/market check " + openListing))
+                            .append(Text.of("[Info]"))
+                            .onHover(TextActions.showText(Text.of("View more info about this listing.")))
+                            .build());
+
+                    texts.add(l.build());
+                }
+                return getPaginationService().builder().contents(texts).title(Texts.MARKET_LISTINGS).build();
+            }
         }
     }
 
     public List<ItemStack> removeListing(String id, String uuid, boolean staff) {
-        try (Jedis jedis = getJedis().getResource()) {
-            if (!jedis.hexists(RedisKeys.forSale(), id)) return null;
-            else {
-                // get info about the listing
-                Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(id));
-                // check to see if the uuid matches the seller, or the user is a staff member
-                if (!listing.get("Seller").equals(uuid) && !staff) return null;
-                // get how much stock it has
-                int inStock = Integer.parseInt(listing.get("Stock"));
-                // deserialize the item
-                ItemStack listingIS = deserializeItemStack(listing.get("Item")).get();
-                // calculate the amount of stacks to make
-                int stacksInStock = inStock / listingIS.getMaxStackQuantity();
-                // new list for stacks
-                List<ItemStack> stacks = new ArrayList<>();
-                // until all stacks are pulled out, keep adding more stacks to stacks
-                for (int i = 0; i < stacksInStock; i++) {
-                    stacks.add(listingIS.copy());
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT seller_uuid, item, stock FROM listings WHERE id = ?")) {
+                ps.setInt(1, Integer.parseInt(id));
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) return null;
+                    String seller = rs.getString("seller_uuid");
+                    if (!seller.equals(uuid) && !staff) return null;
+                    int inStock = rs.getInt("stock");
+                    Optional<ItemStack> item = deserializeItemStack(rs.getString("item"));
+                    if (!item.isPresent()) return null;
+                    ItemStack listingIS = item.get();
+                    int stacksInStock = inStock / listingIS.getMaxStackQuantity();
+                    List<ItemStack> stacks = new ArrayList<>();
+                    for (int i = 0; i < stacksInStock; i++) {
+                        stacks.add(listingIS.copy());
+                    }
+                    if (inStock % listingIS.getMaxStackQuantity() != 0) {
+                        ItemStack extra = listingIS.copy();
+                        extra.setQuantity(inStock % listingIS.getMaxStackQuantity());
+                        stacks.add(extra);
+                    }
+                    try (PreparedStatement del = conn.prepareStatement("DELETE FROM listings WHERE id = ?")) {
+                        del.setInt(1, Integer.parseInt(id));
+                        del.executeUpdate();
+                    }
+                    return stacks;
                 }
-                if (inStock % listingIS.getMaxStackQuantity() != 0) {
-                    ItemStack extra = listingIS.copy();
-                    extra.setQuantity(inStock % listingIS.getMaxStackQuantity());
-                    stacks.add(extra);
+            } catch (SQLException e) {
+                logger.error("Failed to remove listing", e);
+            }
+            return null;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                if (!jedis.hexists(RedisKeys.forSale(), id)) return null;
+                else {
+                    // get info about the listing
+                    Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(id));
+                    // check to see if the uuid matches the seller, or the user is a staff member
+                    if (!listing.get("Seller").equals(uuid) && !staff) return null;
+                    // get how much stock it has
+                    int inStock = Integer.parseInt(listing.get("Stock"));
+                    // deserialize the item
+                    ItemStack listingIS = deserializeItemStack(listing.get("Item")).get();
+                    // calculate the amount of stacks to make
+                    int stacksInStock = inStock / listingIS.getMaxStackQuantity();
+                    // new list for stacks
+                    List<ItemStack> stacks = new ArrayList<>();
+                    // until all stacks are pulled out, keep adding more stacks to stacks
+                    for (int i = 0; i < stacksInStock; i++) {
+                        stacks.add(listingIS.copy());
+                    }
+                    if (inStock % listingIS.getMaxStackQuantity() != 0) {
+                        ItemStack extra = listingIS.copy();
+                        extra.setQuantity(inStock % listingIS.getMaxStackQuantity());
+                        stacks.add(extra);
+                    }
+                    // remove from the listings
+                    jedis.hdel(RedisKeys.forSale(), id);
+                    return stacks;
                 }
-                // remove from the listings
-                jedis.hdel(RedisKeys.forSale(), id);
-                return stacks;
             }
         }
     }
 
     public PaginationList getListing(String id) {
-        try (Jedis jedis = getJedis().getResource()) {
-            // if the item is not for sale, do not get the listing
-            if (!jedis.hexists(RedisKeys.forSale(), id)) return null;
-            // get info about the listing
-            Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(id));
-            // create list of Texts for pages
-            List<Text> texts = new ArrayList<>();
-            // replace with item if key is "Item", replace uuid with name from cache.
-            listing.forEach((key, value) -> {
-                switch (key) {
-                    case "Item":
-                        texts.add(Texts.quickItemFormat(deserializeItemStack(value).get()));
-                        break;
-                    case "Seller":
-                        texts.add(Text.of("Seller: " + jedis.hget(RedisKeys.UUID_CACHE, value)));
-                        break;
-                    default:
-                        texts.add(Text.of(key + ": " + value));
-                        break;
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT seller_uuid, item, stock, price, quantity FROM listings WHERE id = ?")) {
+                ps.setInt(1, Integer.parseInt(id));
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) return null;
+                    List<Text> texts = new ArrayList<>();
+                    texts.add(Texts.quickItemFormat(deserializeItemStack(rs.getString("item")).get()));
+                    texts.add(Text.of("Seller: " + getNameFromUUID(rs.getString("seller_uuid"))));
+                    texts.add(Text.of("Price: " + rs.getInt("price")));
+                    texts.add(Text.of("Quantity: " + rs.getInt("quantity")));
+                    texts.add(Text.of("Stock: " + rs.getInt("stock")));
+                    texts.add(Text.builder()
+                            .append(Text.builder()
+                                    .color(TextColors.GREEN)
+                                    .append(Text.of("[Buy]"))
+                                    .onClick(TextActions.suggestCommand("/market buy " + id))
+                                    .build())
+                            .append(Text.of(" "))
+                            .append(Text.builder()
+                                    .color(TextColors.GREEN)
+                                    .append(Text.of("[QuickBuy]"))
+                                    .onClick(TextActions.runCommand("/market buy " + id))
+                                    .onHover(TextActions.showText(Text.of("Click here to run the command to buy the item.")))
+                                    .build())
+                            .build());
+                    return getPaginationService().builder().title(Texts.MARKET_LISTING(id)).contents(texts).build();
                 }
-            });
+            } catch (SQLException e) {
+                logger.error("Failed to get listing", e);
+            }
+            return null;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                // if the item is not for sale, do not get the listing
+                if (!jedis.hexists(RedisKeys.forSale(), id)) return null;
+                // get info about the listing
+                Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(id));
+                // create list of Texts for pages
+                List<Text> texts = new ArrayList<>();
+                // replace with item if key is "Item", replace uuid with name from cache.
+                listing.forEach((key, value) -> {
+                    switch (key) {
+                        case "Item":
+                            texts.add(Texts.quickItemFormat(deserializeItemStack(value).get()));
+                            break;
+                        case "Seller":
+                            texts.add(Text.of("Seller: " + jedis.hget(RedisKeys.UUID_CACHE, value)));
+                            break;
+                        default:
+                            texts.add(Text.of(key + ": " + value));
+                            break;
+                    }
+                });
 
-            texts.add(Text.builder()
-                    .append(Text.builder()
-                            .color(TextColors.GREEN)
-                            .append(Text.of("[Buy]"))
-                            .onClick(TextActions.suggestCommand("/market buy " + id))
-                            .build())
-                    .append(Text.of(" "))
-                    .append(Text.builder()
-                            .color(TextColors.GREEN)
-                            .append(Text.of("[QuickBuy]"))
-                            .onClick(TextActions.runCommand("/market buy " + id))
-                            .onHover(TextActions.showText(Text.of("Click here to run the command to buy the item.")))
-                            .build())
-                    .build());
+                texts.add(Text.builder()
+                        .append(Text.builder()
+                                .color(TextColors.GREEN)
+                                .append(Text.of("[Buy]"))
+                                .onClick(TextActions.suggestCommand("/market buy " + id))
+                                .build())
+                        .append(Text.of(" "))
+                        .append(Text.builder()
+                                .color(TextColors.GREEN)
+                                .append(Text.of("[QuickBuy]"))
+                                .onClick(TextActions.runCommand("/market buy " + id))
+                                .onHover(TextActions.showText(Text.of("Click here to run the command to buy the item.")))
+                                .build())
+                        .build());
 
-            return getPaginationService().builder().title(Texts.MARKET_LISTING(id)).contents(texts).build();
+                return getPaginationService().builder().title(Texts.MARKET_LISTING(id)).contents(texts).build();
+            }
         }
     }
 
     public boolean addStock(ItemStack itemStack, String id, UUID uuid) {
-        try (Jedis jedis = getJedis().getResource()) {
-            if (!jedis.hexists(RedisKeys.forSale(), id)) return false;
-            else if (!jedis.hget(RedisKeys.marketItemKey(id), "Seller").equals(uuid.toString())) return false;
-            else {
-                ItemStack listingStack = deserializeItemStack(jedis.hget(RedisKeys.marketItemKey(id), "Item")).get();
-                // if the stack in the listing matches the stack it's trying to add, add it to the stack
-                if (matchItemStacks(listingStack, itemStack)) {
-                    int stock = Integer.parseInt(jedis.hget(RedisKeys.marketItemKey(id), "Stock"));
-                    int quan = itemStack.getQuantity() + stock;
-                    jedis.hset(RedisKeys.marketItemKey(id), "Stock", String.valueOf(quan));
-                    return true;
-                } else return false;
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT seller_uuid, item, stock FROM listings WHERE id = ?")) {
+                ps.setInt(1, Integer.parseInt(id));
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) return false;
+                    if (!rs.getString("seller_uuid").equals(uuid.toString())) return false;
+                    ItemStack listingStack = deserializeItemStack(rs.getString("item")).get();
+                    if (matchItemStacks(listingStack, itemStack)) {
+                        int stock = rs.getInt("stock");
+                        int quan = itemStack.getQuantity() + stock;
+                        try (PreparedStatement upd = conn.prepareStatement("UPDATE listings SET stock = ? WHERE id = ?")) {
+                            upd.setInt(1, quan);
+                            upd.setInt(2, Integer.parseInt(id));
+                            upd.executeUpdate();
+                        }
+                        return true;
+                    } else {
+                        return false;
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to add stock", e);
+            }
+            return false;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                if (!jedis.hexists(RedisKeys.forSale(), id)) return false;
+                else if (!jedis.hget(RedisKeys.marketItemKey(id), "Seller").equals(uuid.toString())) return false;
+                else {
+                    ItemStack listingStack = deserializeItemStack(jedis.hget(RedisKeys.marketItemKey(id), "Item")).get();
+                    // if the stack in the listing matches the stack it's trying to add, add it to the stack
+                    if (matchItemStacks(listingStack, itemStack)) {
+                        int stock = Integer.parseInt(jedis.hget(RedisKeys.marketItemKey(id), "Stock"));
+                        int quan = itemStack.getQuantity() + stock;
+                        jedis.hset(RedisKeys.marketItemKey(id), "Stock", String.valueOf(quan));
+                        return true;
+                    } else return false;
+                }
             }
         }
     }
@@ -607,35 +829,76 @@ public class Market {
     }
 
     public ItemStack purchase(UniqueAccount uniqueAccount, String id) {
-        try (Jedis jedis = getJedis().getResource()) {
-            if (!jedis.hexists(RedisKeys.forSale(), id)) return null;
-            else {
-                TransactionResult tr = uniqueAccount.transfer(
-                        getEconomyService().getOrCreateAccount(UUID.fromString(jedis.hget(RedisKeys.marketItemKey(id), "Seller"))).get(),
-                        getEconomyService().getDefaultCurrency(),
-                        BigDecimal.valueOf(Long.parseLong(jedis.hget(RedisKeys.marketItemKey(id), "Price"))),
-                        marketCause // SpongeAPI 7: pass the Cause directly
-                );
-                if (tr.getResult().equals(ResultType.SUCCESS)) {
-                    // get the itemstack
-                    ItemStack is = deserializeItemStack(jedis.hget(RedisKeys.marketItemKey(id), "Item")).get();
-                    // get the quantity per sale
-                    int quant = Integer.parseInt(jedis.hget(RedisKeys.marketItemKey(id), "Quantity"));
-                    // get the amount in stock
-                    int inStock = Integer.parseInt(jedis.hget(RedisKeys.marketItemKey(id), "Stock"));
-                    // get the new quantity
-                    int newQuant = inStock - quant;
-                    // if the new quantity is less than the quantity to be sold, expire the listing
-                    if (newQuant < quant) {
-                        jedis.hdel(RedisKeys.forSale(), id);
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT seller_uuid, item, price, quantity, stock FROM listings WHERE id = ?")) {
+                ps.setInt(1, Integer.parseInt(id));
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (!rs.next()) return null;
+                    TransactionResult tr = uniqueAccount.transfer(
+                            getEconomyService().getOrCreateAccount(UUID.fromString(rs.getString("seller_uuid"))).get(),
+                            getEconomyService().getDefaultCurrency(),
+                            BigDecimal.valueOf(rs.getInt("price")),
+                            marketCause);
+                    if (tr.getResult().equals(ResultType.SUCCESS)) {
+                        ItemStack is = deserializeItemStack(rs.getString("item")).get();
+                        int quant = rs.getInt("quantity");
+                        int inStock = rs.getInt("stock");
+                        int newQuant = inStock - quant;
+                        if (newQuant < quant) {
+                            try (PreparedStatement del = conn.prepareStatement("DELETE FROM listings WHERE id = ?")) {
+                                del.setInt(1, Integer.parseInt(id));
+                                del.executeUpdate();
+                            }
+                        } else {
+                            try (PreparedStatement upd = conn.prepareStatement("UPDATE listings SET stock = ? WHERE id = ?")) {
+                                upd.setInt(1, newQuant);
+                                upd.setInt(2, Integer.parseInt(id));
+                                upd.executeUpdate();
+                            }
+                        }
+                        ItemStack nis = is.copy();
+                        nis.setQuantity(quant);
+                        return nis;
                     } else {
-                        jedis.hset(RedisKeys.marketItemKey(id), "Stock", String.valueOf(newQuant));
+                        return null;
                     }
-                    ItemStack nis = is.copy();
-                    nis.setQuantity(quant);
-                    return nis;
-                } else {
-                    return null;
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to purchase listing", e);
+            }
+            return null;
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                if (!jedis.hexists(RedisKeys.forSale(), id)) return null;
+                else {
+                    TransactionResult tr = uniqueAccount.transfer(
+                            getEconomyService().getOrCreateAccount(UUID.fromString(jedis.hget(RedisKeys.marketItemKey(id), "Seller"))).get(),
+                            getEconomyService().getDefaultCurrency(),
+                            BigDecimal.valueOf(Long.parseLong(jedis.hget(RedisKeys.marketItemKey(id), "Price"))),
+                            marketCause // SpongeAPI 7: pass the Cause directly
+                    );
+                    if (tr.getResult().equals(ResultType.SUCCESS)) {
+                        // get the itemstack
+                        ItemStack is = deserializeItemStack(jedis.hget(RedisKeys.marketItemKey(id), "Item")).get();
+                        // get the quantity per sale
+                        int quant = Integer.parseInt(jedis.hget(RedisKeys.marketItemKey(id), "Quantity"));
+                        // get the amount in stock
+                        int inStock = Integer.parseInt(jedis.hget(RedisKeys.marketItemKey(id), "Stock"));
+                        // get the new quantity
+                        int newQuant = inStock - quant;
+                        // if the new quantity is less than the quantity to be sold, expire the listing
+                        if (newQuant < quant) {
+                            jedis.hdel(RedisKeys.forSale(), id);
+                        } else {
+                            jedis.hset(RedisKeys.marketItemKey(id), "Stock", String.valueOf(newQuant));
+                        }
+                        ItemStack nis = is.copy();
+                        nis.setQuantity(quant);
+                        return nis;
+                    } else {
+                        return null;
+                    }
                 }
             }
         }
@@ -646,18 +909,42 @@ public class Market {
     }
 
     public boolean blacklistAddCmd(String id) {
-        try (Jedis jedis = getJedis().getResource()) {
-            if (jedis.hexists(RedisKeys.BLACKLIST, id)) return false;
-            jedis.hset(RedisKeys.BLACKLIST, id, String.valueOf(true));
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("INSERT IGNORE INTO blacklist(item) VALUES (?)")) {
+                ps.setString(1, id);
+                int rows = ps.executeUpdate();
+                if (rows == 0) return false;
+            } catch (SQLException e) {
+                logger.error("Failed to add blacklist entry", e);
+                return false;
+            }
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                if (jedis.hexists(RedisKeys.BLACKLIST, id)) return false;
+                jedis.hset(RedisKeys.BLACKLIST, id, String.valueOf(true));
+            }
         }
         addIDToBlackList(id);
         return true;
     }
 
     public boolean blacklistRemoveCmd(String id) {
-        try (Jedis jedis = getJedis().getResource()) {
-            if (!jedis.hexists(RedisKeys.BLACKLIST, id)) return false;
-            jedis.hdel(RedisKeys.BLACKLIST, id);
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("DELETE FROM blacklist WHERE item = ?")) {
+                ps.setString(1, id);
+                int rows = ps.executeUpdate();
+                if (rows == 0) return false;
+            } catch (SQLException e) {
+                logger.error("Failed to remove blacklist entry", e);
+                return false;
+            }
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                if (!jedis.hexists(RedisKeys.BLACKLIST, id)) return false;
+                jedis.hdel(RedisKeys.BLACKLIST, id);
+            }
         }
         rmIDFromBlackList(id);
         return true;
@@ -691,77 +978,147 @@ public class Market {
     }
 
     public PaginationList searchForItem(ItemType itemType) {
-        try (Jedis jedis = getJedis().getResource()) {
-            Set<String> openListings = jedis.hgetAll(RedisKeys.forSale()).keySet();
-            List<Text> texts = new ArrayList<>();
-            for (String openListing : openListings) {
-                Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(openListing));
-                Text.Builder l = Text.builder();
-                Optional<ItemStack> is = deserializeItemStack(listing.get("Item"));
-                if (!is.isPresent()) continue;
-                if (is.get().getItem().equals(itemType)) {
+        List<Text> texts = new ArrayList<>();
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT id, seller_uuid, item, price, quantity FROM listings");
+                 ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    Optional<ItemStack> is = deserializeItemStack(rs.getString("item"));
+                    if (!is.isPresent() || !is.get().getItem().equals(itemType)) continue;
+                    Text.Builder l = Text.builder();
                     l.append(Texts.quickItemFormat(is.get()));
                     l.append(Text.of(" "));
                     l.append(Text.of(TextColors.WHITE, "@"));
                     l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.GREEN, "$" + listing.get("Price")));
+                    l.append(Text.of(TextColors.GREEN, "$" + rs.getInt("price")));
                     l.append(Text.of(" "));
                     l.append(Text.of(TextColors.WHITE, "for"));
                     l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.GREEN, listing.get("Quantity") + "x"));
+                    l.append(Text.of(TextColors.GREEN, rs.getInt("quantity") + "x"));
                     l.append(Text.of(" "));
                     l.append(Text.of(TextColors.WHITE, "Seller:"));
-                    l.append(Text.of(TextColors.LIGHT_PURPLE, " " + jedis.hget(RedisKeys.UUID_CACHE, listing.get("Seller"))));
+                    l.append(Text.of(TextColors.LIGHT_PURPLE, " " + getNameFromUUID(rs.getString("seller_uuid"))));
                     l.append(Text.of(" "));
                     l.append(Text.builder()
                             .color(TextColors.GREEN)
-                            .onClick(TextActions.runCommand("/market check " + openListing))
+                            .onClick(TextActions.runCommand("/market check " + rs.getInt("id")))
                             .append(Text.of("[Info]"))
                             .onHover(TextActions.showText(Text.of("View more info about this listing.")))
                             .build());
                     texts.add(l.build());
                 }
+            } catch (SQLException e) {
+                logger.error("Failed to search listings", e);
             }
-            if (texts.size() == 0) texts.add(Text.of(TextColors.RED, "No listings found."));
-            return getPaginationService().builder().contents(texts).title(Texts.MARKET_SEARCH).build();
-        }
-    }
-
-    public PaginationList searchForUUID(UUID uniqueId) {
-        try (Jedis jedis = getJedis().getResource()) {
-            Set<String> openListings = jedis.hgetAll(RedisKeys.forSale()).keySet();
-            List<Text> texts = new ArrayList<>();
-            for (String openListing : openListings) {
-                Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(openListing));
-                if (listing.get("Seller").equals(uniqueId.toString())) {
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                Set<String> openListings = jedis.hgetAll(RedisKeys.forSale()).keySet();
+                for (String openListing : openListings) {
+                    Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(openListing));
                     Text.Builder l = Text.builder();
                     Optional<ItemStack> is = deserializeItemStack(listing.get("Item"));
                     if (!is.isPresent()) continue;
-                    l.append(Texts.quickItemFormat(is.get()));
-                    l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.WHITE, "@"));
-                    l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.GREEN, "$" + listing.get("Price")));
-                    l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.WHITE, "for"));
-                    l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.GREEN, listing.get("Quantity") + "x"));
-                    l.append(Text.of(" "));
-                    l.append(Text.of(TextColors.WHITE, "Seller:"));
-                    l.append(Text.of(TextColors.LIGHT_PURPLE, " " + jedis.hget(RedisKeys.UUID_CACHE, listing.get("Seller"))));
-                    l.append(Text.of(" "));
-                    l.append(Text.builder()
-                            .color(TextColors.GREEN)
-                            .onClick(TextActions.runCommand("/market check " + openListing))
-                            .append(Text.of("[Info]"))
-                            .onHover(TextActions.showText(Text.of("View more info about this listing.")))
-                            .build());
-                    texts.add(l.build());
+                    if (is.get().getItem().equals(itemType)) {
+                        l.append(Texts.quickItemFormat(is.get()));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "@"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.GREEN, "$" + listing.get("Price")));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "for"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.GREEN, listing.get("Quantity") + "x"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "Seller:"));
+                        l.append(Text.of(TextColors.LIGHT_PURPLE, " " + jedis.hget(RedisKeys.UUID_CACHE, listing.get("Seller"))));
+                        l.append(Text.of(" "));
+                        l.append(Text.builder()
+                                .color(TextColors.GREEN)
+                                .onClick(TextActions.runCommand("/market check " + openListing))
+                                .append(Text.of("[Info]"))
+                                .onHover(TextActions.showText(Text.of("View more info about this listing.")))
+                                .build());
+                        texts.add(l.build());
+                    }
                 }
             }
-            if (texts.size() == 0) texts.add(Text.of(TextColors.RED, "No listings found."));
-            return getPaginationService().builder().contents(texts).title(Texts.MARKET_SEARCH).build();
         }
+        if (texts.size() == 0) texts.add(Text.of(TextColors.RED, "No listings found."));
+        return getPaginationService().builder().contents(texts).title(Texts.MARKET_SEARCH).build();
+    }
+
+    public PaginationList searchForUUID(UUID uniqueId) {
+        List<Text> texts = new ArrayList<>();
+        if (useMySql) {
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT id, seller_uuid, item, price, quantity FROM listings WHERE seller_uuid = ?")) {
+                ps.setString(1, uniqueId.toString());
+                try (ResultSet rs = ps.executeQuery()) {
+                    while (rs.next()) {
+                        Text.Builder l = Text.builder();
+                        Optional<ItemStack> is = deserializeItemStack(rs.getString("item"));
+                        if (!is.isPresent()) continue;
+                        l.append(Texts.quickItemFormat(is.get()));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "@"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.GREEN, "$" + rs.getInt("price")));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "for"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.GREEN, rs.getInt("quantity") + "x"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "Seller:"));
+                        l.append(Text.of(TextColors.LIGHT_PURPLE, " " + getNameFromUUID(rs.getString("seller_uuid"))));
+                        l.append(Text.of(" "));
+                        l.append(Text.builder()
+                                .color(TextColors.GREEN)
+                                .onClick(TextActions.runCommand("/market check " + rs.getInt("id")))
+                                .append(Text.of("[Info]"))
+                                .onHover(TextActions.showText(Text.of("View more info about this listing.")))
+                                .build());
+                        texts.add(l.build());
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to search listings", e);
+            }
+        } else {
+            try (Jedis jedis = getJedis().getResource()) {
+                Set<String> openListings = jedis.hgetAll(RedisKeys.forSale()).keySet();
+                for (String openListing : openListings) {
+                    Map<String, String> listing = jedis.hgetAll(RedisKeys.marketItemKey(openListing));
+                    if (listing.get("Seller").equals(uniqueId.toString())) {
+                        Text.Builder l = Text.builder();
+                        Optional<ItemStack> is = deserializeItemStack(listing.get("Item"));
+                        if (!is.isPresent()) continue;
+                        l.append(Texts.quickItemFormat(is.get()));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "@"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.GREEN, "$" + listing.get("Price")));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "for"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.GREEN, listing.get("Quantity") + "x"));
+                        l.append(Text.of(" "));
+                        l.append(Text.of(TextColors.WHITE, "Seller:"));
+                        l.append(Text.of(TextColors.LIGHT_PURPLE, " " + jedis.hget(RedisKeys.UUID_CACHE, listing.get("Seller"))));
+                        l.append(Text.of(" "));
+                        l.append(Text.builder()
+                                .color(TextColors.GREEN)
+                                .onClick(TextActions.runCommand("/market check " + openListing))
+                                .append(Text.of("[Info]"))
+                                .onHover(TextActions.showText(Text.of("View more info about this listing.")))
+                                .build());
+                        texts.add(l.build());
+                    }
+                }
+            }
+        }
+        if (texts.size() == 0) texts.add(Text.of(TextColors.RED, "No listings found."));
+        return getPaginationService().builder().contents(texts).title(Texts.MARKET_SEARCH).build();
     }
 
     public Scheduler getScheduler() {


### PR DESCRIPTION
## Summary
- add configurable storage type allowing MySQL or Redis backends
- implement MySQL-based market storage and blacklist handling

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a581356c8326a5981fe94d25fb4d