### PR TITLE
Handle missing configuration when creating Jedis pool

### DIFF
--- a/src/main/java/com/kookykraftmc/market/Market.java
+++ b/src/main/java/com/kookykraftmc/market/Market.java
@@ -396,16 +396,21 @@ public class Market {
     }
 
     public JedisPool getJedis() {
+        if (cfg == null) {
+            logger.error("Configuration not loaded. Unable to provide Jedis pool.");
+            throw new IllegalStateException("Configuration not loaded");
+        }
+
         if (jedisPool == null) {
             // Use the same case as onPreInit ("Redis")
             if (this.cfg.getNode("Redis", "Use-password").getBoolean()) {
-                return setupRedis(this.redisHost, this.redisPort, this.redisPass);
+                jedisPool = setupRedis(this.redisHost, this.redisPort, this.redisPass);
             } else {
-                return setupRedis(this.redisHost, this.redisPort);
+                jedisPool = setupRedis(this.redisHost, this.redisPort);
             }
-        } else {
-            return jedisPool;
         }
+
+        return jedisPool;
     }
 
     public PaginationService getPaginationService() {


### PR DESCRIPTION
## Summary
- Guard `getJedis` against null configuration
- Cache created `JedisPool` instance for reuse

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b70a9e908326b70dd59c3f6c5488