### PR TITLE
Fix Redis blacklist loading block

### DIFF
--- a/src/main/java/com/kookykraftmc/market/Market.java
+++ b/src/main/java/com/kookykraftmc/market/Market.java
@@ -195,8 +195,6 @@ public class Market {
                 try (Jedis jedis = pool.getResource()) {
                     blacklistedItems = Lists.newArrayList(jedis.hgetAll(RedisKeys.BLACKLIST).keySet());
                 }
-            try (Jedis jedis = getJedis().getResource()) {
-                blacklistedItems = Lists.newArrayList(jedis.hgetAll(RedisKeys.BLACKLIST).keySet());
             }
         }
 


### PR DESCRIPTION
## Summary
- close conditional block before Redis blacklist loading
- drop duplicate Redis try-with-resources call

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6befed1748326b0070921be9aff3c