### PR TITLE
Refactor MySQL initialization logic

### DIFF
--- a/src/main/java/com/kookykraftmc/market/Market.java
+++ b/src/main/java/com/kookykraftmc/market/Market.java
@@ -169,25 +169,21 @@ public class Market {
         marketCause = Cause.of(EventContext.empty(), this);
 
         if (useMySql) {
-            if (database != null) {
-                try (Connection conn = database.getDataSource().getConnection();
-                     PreparedStatement ps = conn.prepareStatement("SELECT item FROM blacklist");
-                     ResultSet rs = ps.executeQuery()) {
-                    blacklistedItems = new ArrayList<>();
-                    while (rs.next()) {
-                        blacklistedItems.add(rs.getString("item"));
-                    }
-                } catch (SQLException e) {
-                    logger.error("Failed to load blacklist from MySQL", e);
-                }
-            } else {
-                logger.error("Fatal error: MySQL initialization failed (database is null). Aborting initialization.");
+            if (database == null) {
+                logger.error("MySQL initialization failed (database is null). Aborting initialization.");
                 return;
             }
-        } else if (useMySql && database == null) {
-            logger.error("MySQL initialization failed (database is null). Check credentials or driver.");
+            try (Connection conn = database.getDataSource().getConnection();
+                 PreparedStatement ps = conn.prepareStatement("SELECT item FROM blacklist");
+                 ResultSet rs = ps.executeQuery()) {
+                blacklistedItems = new ArrayList<>();
+                while (rs.next()) {
+                    blacklistedItems.add(rs.getString("item"));
+                }
+            } catch (SQLException e) {
+                logger.error("Failed to load blacklist from MySQL", e);
+            }
         } else {
-
             JedisPool pool = getJedis();
             if (pool == null) {
                 logger.info("Skipping blacklist loading from Redis; no pool available.");
@@ -195,8 +191,6 @@ public class Market {
                 try (Jedis jedis = pool.getResource()) {
                     blacklistedItems = Lists.newArrayList(jedis.hgetAll(RedisKeys.BLACKLIST).keySet());
                 }
-            try (Jedis jedis = getJedis().getResource()) {
-                blacklistedItems = Lists.newArrayList(jedis.hgetAll(RedisKeys.BLACKLIST).keySet());
             }
         }
 


### PR DESCRIPTION
## Summary
- Simplify initialization into a two-branch `if (useMySql)`/`else`
- Log error and abort when MySQL database is missing
- Load blacklist from Redis only when its pool is available

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6beffcc0c832699c39106bbf14a77