### PR TITLE
Initialize MySQL storage service and start listener

### DIFF
--- a/src/main/java/com/kookykraftmc/market/Market.java
+++ b/src/main/java/com/kookykraftmc/market/Market.java
@@ -146,6 +146,12 @@ public class Market {
                 String sqlPassword = cfg.getNode("MySQL", "Password").getString("");
                 database = new Database(sqlHost, sqlPort, sqlDatabase, sqlUser, sqlPassword, logger);
                 database.runMigrations();
+                try {
+                    sqlStorage = new MySqlStorageService(database.getDataSource(), logger);
+                    subscribe();
+                } catch (SQLException e) {
+                    logger.error("Failed to initialize MySQL storage service", e);
+                }
             } else {
                 this.redisPort = cfg.getNode("Redis", "Port").getInt();
                 this.redisHost = cfg.getNode("Redis", "Host").getString();


### PR DESCRIPTION
## Summary
- Initialize MySqlStorageService after running database migrations
- Handle SQLExceptions during MySqlStorageService creation
- Start SQL listener task upon successful service initialization

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bf00ac5c83269315cf4fd2119fd0