### PR TITLE
Refactor removeListing to return Optional and harden item deserialization

### DIFF
--- a/src/main/java/com/kookykraftmc/market/commands/subcommands/RemoveListingCommand.java
+++ b/src/main/java/com/kookykraftmc/market/commands/subcommands/RemoveListingCommand.java
@@ -31,13 +31,15 @@ public class RemoveListingCommand implements CommandExecutor {
         Player player = (Player) src;
         Optional<String> oid = args.getOne(Text.of("id"));
         oid.ifPresent(s -> {
-            List<ItemStack> is = pl.removeListing(s, player.getUniqueId().toString(), player.hasPermission("market.command.staff.removelisting"));
-            if (is != null) {
-                for (ItemStack i : is) {
+            Optional<List<ItemStack>> is = pl.removeListing(s, player.getUniqueId().toString(), player.hasPermission("market.command.staff.removelisting"));
+            if (is.isPresent()) {
+                for (ItemStack i : is.get()) {
                     player.getInventory().query(Hotbar.class, GridInventory.class).offer(i);
                 }
                 player.sendMessage(Text.of(TextColors.GREEN, "Removed listing " + s + "."));
-            } else player.sendMessage(Texts.INVALID_LISTING);
+            } else {
+                player.sendMessage(Texts.INVALID_LISTING);
+            }
         });
         return CommandResult.success();
     }


### PR DESCRIPTION
## Summary
- Refactor `Market.removeListing` to return `Optional<List<ItemStack>>` instead of null
- Update callers and other market operations to handle missing items without `.get()`
- Replace unsafe `deserializeItemStack(...).get()` usages with `orElseThrow` or presence checks

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c3127aa883268c350c16f1a4b5f7