### PR TITLE
Use try-with-resources for schema loading

### DIFF
--- a/src/main/java/com/kookykraftmc/market/sql/Database.java
+++ b/src/main/java/com/kookykraftmc/market/sql/Database.java
@@ -47,18 +47,21 @@ public class Database {
     }
 
     public void runMigrations() {
-        try (Connection conn = dataSource.getConnection(); Statement st = conn.createStatement()) {
-            InputStream in = getClass().getResourceAsStream("/sql/schema.sql");
+        try (Connection conn = dataSource.getConnection();
+             Statement st = conn.createStatement();
+             InputStream in = getClass().getResourceAsStream("/sql/schema.sql")) {
             if (in == null) {
                 logger.error("Could not load schema.sql");
                 return;
             }
-            String sql = new BufferedReader(new InputStreamReader(in))
-                    .lines().collect(Collectors.joining("\n"));
-            for (String statement : sql.split(";")) {
-                String trimmed = statement.trim();
-                if (!trimmed.isEmpty()) {
-                    st.execute(trimmed);
+
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                String sql = reader.lines().collect(Collectors.joining("\n"));
+                for (String statement : sql.split(";")) {
+                    String trimmed = statement.trim();
+                    if (!trimmed.isEmpty()) {
+                        st.execute(trimmed);
+                    }
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- Load `/sql/schema.sql` using try-with-resources so `InputStream` and `BufferedReader` are always closed

## Testing
- `./gradlew test` *(fails: Some problems were found with the configuration of task ':generateMetadata'...)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c9471464832696c90814dd39fb78