### PR TITLE
chore: update sponge plugin for gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.spongepowered.plugin' version '0.8.1'
+    id 'org.spongepowered.plugin' version '2.2.0'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
@@ -20,7 +20,7 @@ version = PV
 
 repositories {
     mavenCentral()
-    maven { url 'https://repo.spongepowered.org/maven' }
+    maven { url 'https://repo.spongepowered.org/repository/maven-public/' }
     // only if you truly need snapshots:
     // maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,14 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { url "https://repo.spongepowered.org/maven" } // for spongegradle + plugin-meta
+        maven { url "https://repo.spongepowered.org/repository/maven-public/" } // for spongegradle + plugin-meta
         mavenCentral()                                       // harmless extra fallback
     }
     // Optional: make the mapping explicit (works fine with Gradle 6.9.4)
     resolutionStrategy {
         eachPlugin {
             if (requested.id.id == "org.spongepowered.plugin") {
-                useModule("org.spongepowered:spongegradle:${requested.version}")
+                useModule("org.spongepowered:plugin-gradle:${requested.version}")
             }
         }
     }


### PR DESCRIPTION
## Summary
- update Sponge plugin to version 2.2.0 for Gradle 8 compatibility
- point Sponge repositories to `maven-public` and map plugin id to `plugin-gradle`

## Testing
- `./gradlew build` *(fails: Plugin [id: 'org.spongepowered.plugin', version: '2.2.0', artifact: 'org.spongepowered:plugin-gradle:2.2.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c93bf5cc8326b837c9727ddd1ff6