### PR TITLE
Use legacy SpongeGradle 0.8.1 for Sponge API 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.spongepowered.plugin' version '2.2.0'
+    id 'org.spongepowered.plugin' version '0.8.1'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
@@ -41,7 +41,11 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
   }
 
-sponge.plugin.id = PID
+sponge {
+    plugin {
+        id = PID
+    }
+}
 
 tasks.named('shadowJar') {
     // include the libs we want to shade
@@ -64,5 +68,3 @@ tasks.named('shadowJar') {
 tasks.build { dependsOn tasks.shadowJar }
 tasks.jar  { enabled = false }
 
-// disable metadata generation for testing to avoid plugin validation issues
-tasks.named('generateMetadata').configure { enabled = false }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven { url "https://repo.spongepowered.org/repository/maven-public/" } // for spongegradle + plugin-meta
+        maven { url "https://repo.spongepowered.org/repository/maven-public/" } // for plugin-gradle + plugin-meta
         mavenCentral()                                       // harmless extra fallback
     }
     // Optional: make the mapping explicit (works fine with Gradle 6.9.4)


### PR DESCRIPTION
## Summary
- switch to SpongeGradle 0.8.1 for 1.12.2 API 7 compatibility
- resolve SpongeGradle plugin from `plugin-gradle` artifact in pluginManagement

## Testing
- `./gradlew tasks` *(fails: could not resolve `org.spongepowered:plugin-gradle:0.8.1`)*
- `./gradlew test` *(fails: could not resolve `org.spongepowered:plugin-gradle:0.8.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cd2e383c832686124c910c5eee0a